### PR TITLE
Document supporting modules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Federated Learning Communication Metrics Utilities
+
+This repository contains helper modules that make it easier to configure and
+analyse communication-efficient federated learning experiments.  The
+`metrics.py` module adds utilities for summarising loss/accuracy statistics and
+for estimating the bandwidth used to broadcast the global state and ingest
+client updates.
+
+## Repository structure
+
+Although the communication tracking helpers live in `metrics.py`, the project
+also ships several reference components that can be reused when assembling a
+federated learning pipeline:
+
+- `config.py` collects baseline experiment settings and hyper-parameters that
+  can be adapted for individual runs.
+- `data_utils.py` provides dataset preparation helpers that normalise client
+  partitions and central evaluation splits.
+- `ResNet18.py` contains a torchvision-inspired CNN backbone that can serve as
+  the shared model in image classification experiments.
+- `effnet.py` mirrors the EfficientNet-style architecture that some
+  communication efficient baselines employ.
+
+These modules are intentionally lightweight so that they can be imported into
+your own training scripts or modified to suit custom research scenarios.
+
+## Tracking communication traffic
+
+The :class:`~metrics.CommunicationMetricsTracker` class centralises the logic for
+collecting round level metrics.  It automatically keeps running totals for
+uploads and downloads and augments a user supplied report dictionary with
+summary statistics such as the mean/standard deviation of training losses.
+
+```python
+from metrics import CommunicationMetricsTracker
+
+tracker = CommunicationMetricsTracker()
+report = tracker.summarise_round(
+    training_losses=[0.5, 0.42, 0.47],
+    client_accuracies=[0.81, 0.79, 0.83],
+    server_accuracies=[0.80, 0.82],
+    global_state=server_state_dict,
+    participating_updates=[client_1_update, client_2_update],
+)
+```
+
+The tracker uses the :func:`~metrics.tensor_dict_bytes` helper to estimate the
+number of bytes transferred by serialising the provided mappings.  Nested
+mappings and tensor containers are supported out of the box.
+
+## Working with quantised models
+
+When model parameters are quantised before being transmitted, the default byte
+count estimation based on tensor element sizes might not be accurate.  To
+address this, both :func:`~metrics.tensor_dict_bytes` and
+:class:`~metrics.CommunicationMetricsTracker` expose two knobs:
+
+- `dtype_size_overrides`: a mapping that specifies custom element sizes (in
+  bytes) for individual dtypes.  Keys can be dtype objects or their string
+  representations, which allows passing entries such as
+  `{torch.float32: 1, "torch.quint8": 1}`.
+- `default_tensor_element_size`: a fallback element size in bytes that is used
+  when a tensor does not expose size information and no dtype specific override
+  exists.
+
+For example, if the global model is quantised to 8-bit values before being sent
+out to clients you can instantiate the tracker like this:
+
+```python
+tracker = CommunicationMetricsTracker(
+    dtype_size_overrides={"torch.float32": 1},
+    default_tensor_element_size=1,
+)
+```
+
+Quantised tensors produced by PyTorch are detected automatically and their
+integer representation is used when estimating the payload.  The overrides above
+are therefore only necessary when additional custom compression schemes are in
+use.
+
+Run `python -m compileall .` after editing the module to ensure there are no
+syntax errors.

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,321 @@
+"""Utilities for aggregating training statistics and estimating communication traffic.
+
+This module contains helper functionality that can be used when running
+federated-learning style experiments.  The central entry point is the
+:class:`CommunicationMetricsTracker` which can be used to accumulate the
+communication volume across multiple rounds while summarising statistics of the
+metrics reported by participating clients.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
+
+import math
+import numpy as np
+
+
+def _lookup_size_override(
+    dtype: Any, overrides: Optional[Mapping[Any, int]]
+) -> Optional[int]:
+    """Return an override element size for ``dtype`` if available."""
+
+    if not overrides:
+        return None
+
+    candidates = [dtype]
+
+    # ``numpy`` dtypes expose a ``name`` attribute while ``torch`` dtypes can be
+    # turned into strings that uniquely identify them (e.g. ``torch.float32``).
+    name = getattr(dtype, "name", None)
+    if name is not None:
+        candidates.append(name)
+    if dtype is not None:
+        candidates.append(str(dtype))
+
+    for candidate in candidates:
+        if candidate in overrides:
+            return int(overrides[candidate])
+    return None
+
+
+def _tensor_like_nbytes(
+    value: Any,
+    *,
+    dtype_size_overrides: Optional[Mapping[Any, int]] = None,
+    default_element_size: Optional[int] = None,
+) -> int:
+    """Return the number of bytes required to serialise ``value``.
+
+    The helper understands ``torch.Tensor`` instances, :class:`numpy.ndarray`
+    objects, builtin ``bytes``/``bytearray`` values and (nested) containers that
+    yield one of those types.  Optional ``dtype_size_overrides`` and
+    ``default_element_size`` arguments allow callers to adjust the calculation
+    for scenarios such as model quantisation.  The function falls back to the
+    ``nbytes`` attribute for objects such as tensors living on special device
+    wrappers.  ``RuntimeError`` is raised for unsupported values so that
+    mistakes become visible during development instead of silently producing
+    incorrect traffic estimations.
+    """
+
+    if value is None:
+        return 0
+
+    # ``torch`` is an optional dependency.  Importing locally avoids paying the
+    # cost when it is not installed while still allowing us to handle tensors.
+    try:  # pragma: no cover - import guard is trivial to reason about.
+        import torch  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - exercised when torch missing.
+        torch = None  # type: ignore
+
+    if torch is not None and isinstance(value, torch.Tensor):
+        override = _lookup_size_override(getattr(value, "dtype", None), dtype_size_overrides)
+        if override is not None:
+            return int(value.nelement()) * override
+
+        if getattr(value, "is_quantized", False):
+            try:
+                int_repr = value.int_repr()
+            except (RuntimeError, AttributeError):
+                int_repr = None
+
+            if int_repr is not None:
+                base = int(int_repr.nelement()) * int(int_repr.element_size())
+                # Account for quantization metadata.  Per-tensor quantisation stores
+                # ``scale`` and ``zero_point`` values while per-channel additionally
+                # tracks the axis.  We conservatively count float32/int32 values.
+                try:
+                    scales = value.q_per_channel_scales()
+                    zero_points = value.q_per_channel_zero_points()
+                    metadata = (
+                        int(scales.nelement()) * int(scales.element_size())
+                        + int(zero_points.nelement()) * int(zero_points.element_size())
+                        + 4  # channel axis as a 32-bit integer
+                    )
+                except (RuntimeError, AttributeError):
+                    # Per-tensor quantisation exposes scalar accessors instead of
+                    # tensors.  We model them as 32-bit values.
+                    metadata = 8
+
+                return base + metadata
+
+        element_size = None
+        try:
+            element_size = int(value.element_size())
+        except (AttributeError, TypeError):
+            element_size = None
+
+        if element_size is None or element_size == 0:
+            element_size = _lookup_size_override(type(value), dtype_size_overrides)
+
+        if element_size is None:
+            element_size = default_element_size
+
+        if element_size is None:
+            raise RuntimeError(
+                "Unable to determine element size for tensor while estimating traffic"
+            )
+
+        return int(value.nelement()) * int(element_size)
+
+    if isinstance(value, np.ndarray):
+        override = _lookup_size_override(value.dtype, dtype_size_overrides)
+        if override is not None:
+            return int(value.size) * override
+        return int(value.nbytes)
+
+    if hasattr(value, "nbytes") and isinstance(value.nbytes, (int, float)):
+        return int(value.nbytes)
+
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return len(value)
+
+    if isinstance(value, Mapping):
+        return tensor_dict_bytes(
+            value,
+            dtype_size_overrides=dtype_size_overrides,
+            default_element_size=default_element_size,
+        )
+
+    if isinstance(value, (list, tuple)):
+        return sum(
+            _tensor_like_nbytes(
+                v,
+                dtype_size_overrides=dtype_size_overrides,
+                default_element_size=default_element_size,
+            )
+            for v in value
+        )
+
+    raise RuntimeError(
+        "Unsupported value encountered while estimating tensor dictionary size: "
+        f"{type(value)!r}"
+    )
+
+
+def tensor_dict_bytes(
+    tensors: Mapping[Any, Any],
+    *,
+    dtype_size_overrides: Optional[Mapping[Any, int]] = None,
+    default_element_size: Optional[int] = None,
+) -> int:
+    """Return the total number of bytes consumed by a tensor dictionary.
+
+    Parameters
+    ----------
+    tensors:
+        Mapping that contains tensors or other supported container objects.
+    dtype_size_overrides:
+        Optional mapping that specifies custom byte sizes for individual
+        ``dtype`` values.  Keys can be the actual dtype instances or their
+        string representations.
+    default_element_size:
+        Fallback element size (in bytes) used when a dtype specific override is
+        not available and no direct size information can be inferred.
+
+    Returns
+    -------
+    int
+        Estimated number of bytes when serialising the mapping.
+    """
+
+    return sum(
+        _tensor_like_nbytes(
+            value,
+            dtype_size_overrides=dtype_size_overrides,
+            default_element_size=default_element_size,
+        )
+        for value in tensors.values()
+    )
+
+
+def _mean_and_std(values: Sequence[float]) -> Tuple[float, float]:
+    """Return the mean and standard deviation of ``values``.
+
+    ``numpy`` is used for the actual computation to keep the implementation
+    concise.  The helper gracefully handles empty and single element sequences by
+    returning ``math.nan``/``0.0`` respectively.
+    """
+
+    if not values:
+        return math.nan, math.nan
+    if len(values) == 1:
+        return float(values[0]), 0.0
+
+    array = np.asarray(values, dtype=np.float64)
+    return float(array.mean()), float(array.std(ddof=0))
+
+
+def _prepare_sequence(values: Iterable[Union[float, int]]) -> List[float]:
+    """Materialise ``values`` into a list of floats."""
+
+    return [float(v) for v in values]
+
+
+@dataclass
+class CommunicationMetricsTracker:
+    """Track statistics for federated learning rounds.
+
+    The tracker keeps cumulative upload and download traffic and provides a
+    convenience :meth:`summarise_round` method that collects descriptive
+    statistics for training loss and accuracies.  ``dtype_size_overrides`` and
+    ``default_tensor_element_size`` allow fine tuning the traffic estimation for
+    situations where tensors are transmitted using custom precisions (for
+    example after quantisation).
+    """
+
+    total_upload_traffic: int = 0
+    total_download_traffic: int = 0
+    report_defaults: Mapping[str, Any] = field(default_factory=dict)
+    dtype_size_overrides: Mapping[Any, int] = field(default_factory=dict)
+    default_tensor_element_size: Optional[int] = 4
+
+    def summarise_round(
+        self,
+        *,
+        training_losses: Iterable[Union[float, int]],
+        client_accuracies: Iterable[Union[float, int]],
+        server_accuracies: Iterable[Union[float, int]],
+        global_state: Mapping[Any, Any],
+        participating_updates: Iterable[Mapping[Any, Any]],
+        report: Optional[MutableMapping[str, Any]] = None,
+    ) -> MutableMapping[str, Any]:
+        """Summarise statistics for a single FL communication round.
+
+        Parameters
+        ----------
+        training_losses, client_accuracies, server_accuracies:
+            Numeric measurements collected during the round.  Iterables are
+            materialised internally to allow for generator inputs.
+        global_state:
+            Mapping representing the state distributed to clients.
+        participating_updates:
+            Iterable of updates returned by the participating clients.
+        report:
+            Optional mapping that is updated with the computed statistics.
+
+        Returns
+        -------
+        MutableMapping[str, Any]
+            The mapping that contains the combined statistics.
+        """
+
+        report_mapping: MutableMapping[str, Any]
+        if report is None:
+            report_mapping = dict(self.report_defaults)
+        else:
+            report_mapping = report
+
+        losses = _prepare_sequence(training_losses)
+        acc_clients = _prepare_sequence(client_accuracies)
+        acc_servers = _prepare_sequence(server_accuracies)
+
+        training_loss_mean, training_loss_std = _mean_and_std(losses)
+        acc_clients_mean, acc_clients_std = _mean_and_std(acc_clients)
+        acc_servers_mean, acc_servers_std = _mean_and_std(acc_servers)
+
+        report_mapping.update(
+            {
+                "training_loss_mean": training_loss_mean,
+                "training_loss_std": training_loss_std,
+                "acc_clients_mean": acc_clients_mean,
+                "acc_clients_std": acc_clients_std,
+                "acc_servers_mean": acc_servers_mean,
+                "acc_servers_std": acc_servers_std,
+                "training_loss_lowest": training_loss_mean - training_loss_std,
+                "training_loss_highest": training_loss_mean + training_loss_std,
+                "acc_clients_lowest": acc_clients_mean - acc_clients_std,
+                "acc_clients_highest": acc_clients_mean + acc_clients_std,
+                "acc_servers_lowest": acc_servers_mean - acc_servers_std,
+                "acc_servers_highest": acc_servers_mean + acc_servers_std,
+            }
+        )
+
+        download_traffic = tensor_dict_bytes(
+            global_state,
+            dtype_size_overrides=self.dtype_size_overrides,
+            default_element_size=self.default_tensor_element_size,
+        )
+        upload_traffic = sum(
+            tensor_dict_bytes(
+                update,
+                dtype_size_overrides=self.dtype_size_overrides,
+                default_element_size=self.default_tensor_element_size,
+            )
+            for update in participating_updates
+        )
+
+        self.total_upload_traffic += upload_traffic
+        self.total_download_traffic += download_traffic
+
+        report_mapping.update(
+            {
+                "upload_traffic": upload_traffic,
+                "download_traffic": download_traffic,
+                "overall_traffic": self.total_upload_traffic + self.total_download_traffic,
+                "total_upload_traffic": self.total_upload_traffic,
+                "total_download_traffic": self.total_download_traffic,
+            }
+        )
+
+        return report_mapping


### PR DESCRIPTION
## Summary
- add a repository structure section to the README so the bundled model, data, and configuration helpers are discoverable

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ce244ad65483278f36379cb3e30eb4